### PR TITLE
Fix bug that Content-Encoding won't be written to final response header for gzip and deflate

### DIFF
--- a/compress_test.go
+++ b/compress_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aurowora/compress"
+	compress "github.com/lf4096/gin-compress"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )

--- a/decompress_test.go
+++ b/decompress_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/andybalholm/brotli"
-	"github.com/aurowora/compress"
+	compress "github.com/lf4096/gin-compress"
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zlib"
 	"github.com/klauspost/compress/zstd"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aurowora/compress
+module github.com/lf4096/gin-compress
 
 go 1.16
 

--- a/middleware.go
+++ b/middleware.go
@@ -44,14 +44,9 @@ func (cm *compressMiddleware) Handler(c *gin.Context) {
 		return
 	}
 
-	rw := newResponseWriter(c, cm.cfg.minCompressBytes, algorithms[algo])
+	rw := newResponseWriter(c, cm.cfg.minCompressBytes, algo, algorithms[algo])
 	c.Writer = rw
 	c.Next()
-
-	if rw.Swapped() {
-		rw.ResponseWriter.Header().Set("Content-Encoding", algo)
-		rw.ResponseWriter.Header().Set("Vary", "Accept-Encoding")
-	}
 
 	_ = rw.Close()
 }


### PR DESCRIPTION
For gzip and deflate, gin.ResponseWriter.Write() will be called before ResponseWriter.Header().Set(). In this case, the ResponseWriter.Write() will call ResponseWriter.WriteHeaderNow(), and write the header to final response without encoding related headers. In this fix, ResponseWriter.Header().Set() was moved to before any call to gin.ResponseWriter.Write().